### PR TITLE
Improve ADK service reconnect logic

### DIFF
--- a/projects/agent-ui/README.md
+++ b/projects/agent-ui/README.md
@@ -5,7 +5,7 @@ Angular components and services for integrating ADK agents with the AG-UI protoc
 ## Features
 
 * **AGUIEvent** – typed union describing the different kinds of events that can be emitted by an AG‑UI agent.
-* **AgentUiAdkService** – connects to an ADK server‑sent event stream and converts incoming ADK events into `AGUIEvent` objects.
+* **AgentUiAdkService** – connects to an ADK server‑sent event stream, converts incoming ADK events into `AGUIEvent` objects and automatically reconnects when the stream closes. A `disconnect()` method can be used to close the connection manually.
 * **AgentUiRendererComponent** – standalone component that renders an `Observable<AGUIEvent>` stream for quick prototyping.
 * **FirebaseSessionService** – helper for persisting sessions in Firebase; automatically performs anonymous sign‑in and exposes a `BehaviorSubject` representing the current session state.
 

--- a/projects/agent-ui/src/lib/services/agent-ui-adk.service.spec.ts
+++ b/projects/agent-ui/src/lib/services/agent-ui-adk.service.spec.ts
@@ -5,4 +5,9 @@ describe('AgentUiAdkService', () => {
     const service = new AgentUiAdkService();
     expect(service).toBeTruthy();
   });
+
+  it('should expose disconnect', () => {
+    const service = new AgentUiAdkService();
+    expect(typeof service.disconnect).toBe('function');
+  });
 });


### PR DESCRIPTION
## Summary
- reconnect to ADK `run_sse` streams with exponential backoff
- add disconnect API and expose observable via Subject
- document the new reconnect behaviour
- add spec for the disconnect method

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728ca5a7f0832eb16bd11fc9f554d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event stream connection to automatically reconnect if the connection is lost.
  * Added a manual disconnect option for greater control over the event stream connection.

* **Documentation**
  * Updated documentation to reflect enhanced connection and disconnection capabilities.

* **Tests**
  * Added tests to verify the presence and functionality of the new disconnect method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->