### PR TITLE
Implement official run_sse contract

### DIFF
--- a/apps/demo-agent/src/app.component.ts
+++ b/apps/demo-agent/src/app.component.ts
@@ -12,6 +12,6 @@ import { AgentUiAdkService, AgentUiRendererComponent } from '@ag-ui/angular-adk'
   `
 })
 export class AppComponent {
-  events$ = this.agent.connect('http://localhost:8000/run_sse');
+  events$ = this.agent.connect('http://localhost:8000/run_sse', { message: 'Hello' });
   constructor(private agent: AgentUiAdkService) {}
 }

--- a/projects/agent-ui/README.md
+++ b/projects/agent-ui/README.md
@@ -5,7 +5,7 @@ Angular components and services for integrating ADK agents with the AG-UI protoc
 ## Features
 
 * **AGUIEvent** – typed union describing the different kinds of events that can be emitted by an AG‑UI agent.
-* **AgentUiAdkService** – connects to an ADK server‑sent event stream, converts incoming ADK events into `AGUIEvent` objects and automatically reconnects when the stream closes. A `disconnect()` method can be used to close the connection manually.
+* **AgentUiAdkService** – opens a POST `run_sse` connection, converts incoming ADK events into `AGUIEvent` objects and automatically reconnects when the stream closes. A `disconnect()` method can be used to close the connection manually.
 * **AgentUiRendererComponent** – standalone component that renders an `Observable<AGUIEvent>` stream for quick prototyping.
 * **FirebaseSessionService** – helper for persisting sessions in Firebase; automatically performs anonymous sign‑in and exposes a `BehaviorSubject` representing the current session state.
 

--- a/projects/agent-ui/src/lib/services/agent-ui-adk.service.spec.ts
+++ b/projects/agent-ui/src/lib/services/agent-ui-adk.service.spec.ts
@@ -10,4 +10,13 @@ describe('AgentUiAdkService', () => {
     const service = new AgentUiAdkService();
     expect(typeof service.disconnect).toBe('function');
   });
+
+  it('connect should return an observable', () => {
+    const service = new AgentUiAdkService();
+    const stream = service.connect('/agents/a/run_sse', { foo: 'bar' }, {
+      'X-Agent-Run-ID': 'test'
+    });
+    expect(typeof (stream as any).subscribe).toBe('function');
+    service.disconnect();
+  });
 });


### PR DESCRIPTION
## Summary
- implement POST-based SSE logic in `AgentUiAdkService`
- update demo app to pass a payload
- document the run_sse behaviour
- expand service unit tests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728fa8bb5c832eb2de8dcc849e752c