### PR TITLE
Add index re-exports for Angular library

### DIFF
--- a/libs/agent-ui/src/index.ts
+++ b/libs/agent-ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/agent-ui.exports';

--- a/libs/agent-ui/src/lib/agent-ui.exports.ts
+++ b/libs/agent-ui/src/lib/agent-ui.exports.ts
@@ -1,0 +1,4 @@
+export * from './services/agent-ui-adk.service';
+export * from './services/firebase-session.service';
+export * from './components/agent-ui-renderer.component';
+export * from './ag-ui-event';


### PR DESCRIPTION
## Summary
- add `libs/agent-ui` to host public API
- re-export library features through `agent-ui.exports.ts`

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872918b2c0c832eb012374c52ab50ec