### PR TITLE
Replace Karma with Jest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,21 @@
+import { pathsToModuleNameMapper } from 'ts-jest';
+import { compilerOptions } from './tsconfig.json';
+
+export default {
+  preset: 'jest-preset-angular',
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.html$',
+    },
+  },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths || {}, {
+    prefix: '<rootDir>/',
+  }),
+  transform: {
+    '^.+\\.(ts|js|html)$': 'ts-jest',
+  },
+  testEnvironment: 'jsdom',
+  testMatch: ['**/+(*.)+(spec).+(ts)'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,13 +26,10 @@
         "@angular/cli": "^20.0.0",
         "@angular/compiler": "^20.0.0",
         "@angular/compiler-cli": "^20.0.0",
-        "@types/jasmine": "~5.1.0",
-        "jasmine-core": "~5.1.0",
-        "karma": "~6.4.2",
-        "karma-chrome-launcher": "~3.2.0",
-        "karma-coverage": "~2.2.0",
-        "karma-jasmine": "~5.1.0",
-        "karma-jasmine-html-reporter": "~2.1.0",
+        "@types/jest": "^29.5.0",
+        "jest": "^29.5.0",
+        "jest-preset-angular": "^13.1.0",
+        "ts-jest": "^29.1.0",
         "ng-packagr": "^20.0.0",
         "typescript": "~5.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "ng serve demo-agent",
     "build": "ng build agent-ui",
-    "test": "ng test",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
@@ -29,13 +30,10 @@
     "@angular/cli": "^20.0.0",
     "@angular/compiler": "^20.0.0",
     "@angular/compiler-cli": "^20.0.0",
-    "@types/jasmine": "~5.1.0",
-    "jasmine-core": "~5.1.0",
-    "karma": "~6.4.2",
-    "karma-chrome-launcher": "~3.2.0",
-    "karma-coverage": "~2.2.0",
-    "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.1.0",
+    "@types/jest": "^29.5.0",
+    "jest": "^29.5.0",
+    "jest-preset-angular": "^13.1.0",
+    "ts-jest": "^29.1.0",
     "ng-packagr": "^20.0.0",
     "typescript": "~5.8.0"
   }

--- a/projects/agent-ui/tsconfig.spec.json
+++ b/projects/agent-ui/tsconfig.spec.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
-    "types": ["jasmine"]
+    "types": ["jest"]
   },
-  "files": ["src/test.ts"],
+  "files": [],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';


### PR DESCRIPTION
## Summary
- swap Angular Karma setup for Jest
- configure Jest runner
- adjust TypeScript settings for Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d7002ad8832eb1ba2f9536f7234c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the project's testing framework from Jasmine/Karma to Jest for improved testing capabilities.
  * Updated test scripts to use Jest, including a new "test:watch" script for running tests in watch mode.
  * Added configuration files and dependencies to support Jest with Angular projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->